### PR TITLE
Update MinifyResponse.php (#9)

### DIFF
--- a/src/Middleware/MinifyResponse.php
+++ b/src/Middleware/MinifyResponse.php
@@ -21,7 +21,7 @@ class MinifyResponse
         /** @var Response $response */
         $response = $next($request);
 
-        if (!app()->isLocal() && $this->isHtml($response)) {
+        if (config('app.debug') === false && $this->isHtml($response)) {
             $response->setContent((new Minifier())->html($response->getContent()));
         }
 


### PR DESCRIPTION
Phpunit uses APP_ENV=testing by default. With !app()->isLocal(), laravel during tests minifies the response, which causes problems, for example, $response->assertViewIs does not work properly.